### PR TITLE
Add ARIA "img" role for temporary placeholder

### DIFF
--- a/core-image.html
+++ b/core-image.html
@@ -152,7 +152,7 @@ Examples:
        */
       role: {
         reflect: true,
-        value: "img"
+        value: 'img'
       },
 
       /**

--- a/core-image.html
+++ b/core-image.html
@@ -66,10 +66,10 @@ Examples:
 <template>
   <link rel="stylesheet" href="core-image.css">
   <template if="{{!sizing}}">
-    <img id="img">
+    <img id="img" role="none">
   </template>
   <template if="{{preload && fade}}">
-    <div id="placeholder" role="img" fit></div>
+    <div id="placeholder" fit></div>
   </template>
   <content></content>
 </template>
@@ -141,6 +141,19 @@ Examples:
        * @default null
        */
       placeholder: null,
+
+      /**
+       * ARIA role for this element. It defaults to `img` since this element is
+       * intended to be behave like an `<img>`.
+       *
+       * @attribute role
+       * @type string
+       * @default "img"
+       */
+      role: {
+        reflect: true,
+        value: "img"
+      },
 
       /**
        * When `preload` is true, setting `fade` to true will cause the image to

--- a/core-image.html
+++ b/core-image.html
@@ -69,7 +69,7 @@ Examples:
     <img id="img">
   </template>
   <template if="{{preload && fade}}">
-    <div id="placeholder" fit></div>
+    <div id="placeholder" role="img" fit></div>
   </template>
   <content></content>
 </template>


### PR DESCRIPTION
Because the placeholder is intended as a img replacement while loading
is happening, it should be treated as an img by screen readers.

Fixes #12.
