### PR TITLE
Fixing Github Issue #5 Shadow DOM img rendered with bottom "padding"

### DIFF
--- a/core-image.css
+++ b/core-image.css
@@ -11,12 +11,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   display: inline-block;
   overflow: hidden;
   position: relative;
+  line-height: 0;
 }
 
 #placeholder {
   background-color: inherit;
   opacity: 1;
 }
+
 #placeholder.fadein {
   transition: opacity 0.5s linear;
   opacity: 0;


### PR DESCRIPTION
Fix for https://github.com/Polymer/core-image/issues/5

Here is a reduced test case showing the issue: http://jsbin.com/jufiga/4/